### PR TITLE
Update bootloader readme

### DIFF
--- a/Bootloader/README.md
+++ b/Bootloader/README.md
@@ -51,7 +51,7 @@ avrdude -v -p m2560 -c usbasp -P usb -U lock:w:0x3F:m -U efuse:w:0xFD:m -U hfuse
 avrdude -v -p m2560 -P usb -c usbasp -U flash:w:MightyBoardFirmware-2560-bootloader/stk500boot_v2_mega2560.hex:i -U lock:w:0x0f:m
 ```
 
-11. Disconnect 
+11. Disconnect the USBasp cable.  You're done loading the bootloader!
 
 ## About the [dcnewman](https://github.com/dcnewman/MightyBoardFirmware-2560-bootloader) Distribuion
 

--- a/Bootloader/README.md
+++ b/Bootloader/README.md
@@ -24,7 +24,7 @@ By using this guide you are fully aware of the risks involved by such modificati
 ![ICSP Connectors](./../img/ubsasp_icsp_position2.jpg)
 
 > [!NOTE]
-> Ensure that the motherboard is powered. The USBasp cable should provide sufficient power, but if it does not, you will need to supply power otherwise.
+> Ensure that the motherboard is powered. The USBasp cable should provide 5V of power, but if it does not, you will need to supply power otherwise.
 
 5. Open a command terminal and navigate to the downloaded `Bootloader/` folder.
 

--- a/Bootloader/README.md
+++ b/Bootloader/README.md
@@ -1,6 +1,6 @@
 # Bootloader for Flashforge Creator Pro Motherboard
 
-The FFCP motherboard used in this steps  was **FF_CreatorBoard_REV D 20140320**. This motherboard is based on a MightyBoard with ATMEGA2560. Probably any motherboard based on MightyBoard will work with this procedure.
+The FFCP motherboard used in this steps is the **FF_CreatorBoard_REV D 20140320**. This motherboard is based on a MightyBoard with ATMEGA2560, so possibly any MightyBoard-based motherboard will work with this procedure.
 
 ## :warning: USE AT YOUR OWN RISK :warning:
 By using this guide you are fully aware of the risks involved by such modifications. I hereby take no responsibility for any loss and/or damage to property and/or personnel involved.
@@ -9,36 +9,35 @@ By using this guide you are fully aware of the risks involved by such modificati
 
 > I recommend upgrade your USBasp for the last version (usbasp.2011-05-28). There are a lot of information about it on the internet, but [this tutorial](https://atmega32-avr.com/firmware-upgrade-for-usbasp-clone-fixing-error-setting-usbasp-isp-clock/) or [these steps](https://www.instructables.com/How-to-Update-the-Firmware-on-a-Cheap-USBasp-Clone/) are a good start point.
 
-1. Download the .hex files in [Bootloader/](./Bootloader) (I recommend to clone this repository).
+1. Install [AVRDUDE](https://github.com/avrdudes/avrdude) to your computer.
 
-2. Download the [AVRDUDE](https://www.nongnu.org/avrdude/) and unzip it in a folder of your preference
+2. Either clone this repository locally, or download the [`Bootloader/`](./) folder.
 
-3. Copy the .hex files to the your AVRDUDE folder
-    * Bootloader/8U2_firmware/Makerbot-usbserial.hex
-    * Bootloader/MightyBoardFirmware-2560-bootloader/stk500boot_v2_mega2560.hex
-
-4. Access the motherboard, lay the printer down or put it upside down and loose the screws below it and take the metal cover off. Locate the "8U2 ICSP" and "1280 ICSP" 6-pin header connector.
+3. Access the printer's motherboard.  Lay the printer down or put it upside down and remove the screws on the bottom metal plate, then take the plate off. Locate the "8U2 ICSP" and "1280 ICSP" 6-pin header connector.
 
 ![ICSP Connectors](./../img/ffcp_motherboard_icsp.jpg)
 
-5. Connect the USBasp cable at "8U2 ICSP" cheking the correct position. The picture below shows the reference pin.
+4. Connect the USBasp cable to the "8U2 ICSP" port, ensuring it is oriented correctly (the MSIO pin on the adapter should align with the white dot on the motherboard). The picture below shows the reference pin.
 
 ![ICSP Connectors](./../img/ubsasp_icsp_position1.jpg)
 
 ![ICSP Connectors](./../img/ubsasp_icsp_position2.jpg)
 
-> Ensure the Board is Powered by USBasp or power cable
+> [!NOTE]
+> Ensure that the motherboard is powered. The USBasp cable should provide sufficient power, but if it does not, you will need to supply power otherwise.
 
-6. Open command terminal and navigate to the AVRDUDE directory 
+5. Open a command terminal and navigate to the downloaded `Bootloader/` folder.
 
-7. Load the 8U2 with bootloader, and set proper lock bits using this command:
+7. Load the 8U2 with bootloader and set proper lock bits using this command:
 
 ```bash
-avrdude -v -C avrdude.conf -p m8u2 -P usb -c usbasp -U flash:w:Makerbot-usbserial.hex:i -U lfuse:w:0xFF:m -U hfuse:w:0xD9:m -U efuse:w:0xF4:m -U lock:w:0x0F:m 
+avrdude -v -p m8u2 -P usb -c usbasp -U flash:w:8U2_firmware/Makerbot-usbserial.hex:i -U lfuse:w:0xFF:m -U hfuse:w:0xD9:m -U efuse:w:0xF4:m -U lock:w:0x0F:m 
 ```
-> If unsuccessful ("Error in USB Receive"), try again.  It sometimes takes a few tries
 
-8. Take the USBasp cable off and connect at "1280 ICSP" (atention with the cable position).
+> [!NOTE]
+> If the command is unsuccessful with the message `Error in USB Receive`, try running the command again.  It sometimes takes a few tries.
+
+8. Take the USBasp cable out and connect it to the "1280 ICSP" port (again, make sure it's oriented correctly; the orientation is the same).
 
 9. Unlock the memory on your target board and erase the flash (if nessessary). You can also set the fuse bits at the same time with this command:
 
@@ -49,8 +48,10 @@ avrdude -v -p m2560 -c usbasp -P usb -U lock:w:0x3F:m -U efuse:w:0xFD:m -U hfuse
 10. Load the ATMEGA2560 with the bootloader, and set proper lock bits using this command:
 
 ```bash
-avrdude -v -C avrdude.conf -p m2560 -P usb -c usbasp -U flash:w:stk500boot_v2_mega2560.hex:i -U lock:w:0x0f:m
+avrdude -v -p m2560 -P usb -c usbasp -U flash:w:MightyBoardFirmware-2560-bootloader/stk500boot_v2_mega2560.hex:i -U lock:w:0x0f:m
 ```
+
+11. Disconnect 
 
 ## About the [dcnewman](https://github.com/dcnewman/MightyBoardFirmware-2560-bootloader) Distribuion
 


### PR DESCRIPTION
This updates the instructions for uploading the bootloader by performing the following:

- Link to the AVRDUDE GitHub repository
  - The old website is no longer maintained and specifically states that the project moved to GitHub
  - The downloads on the website require manual compilation, and this guide does not specify this
    - The instructions on GitHub mention that you can install AVRDUDE with a package manager (such as `apt` or Homebrew)
- Remove manual specification of `avrdude.conf`
  - Including the `-C avrdude.conf` command line argument is redundant on manual compilation of AVRDUDE, and causes a command failure on precompiled versions
- Update the filepaths to be relative to this folder
  - Saves a small amount of time by having them just CD to `Bootloader/`, instead of back and forth between the two subfolders
- Correct and update grammar